### PR TITLE
Simple patch to allow environment variables to control window class

### DIFF
--- a/main.c
+++ b/main.c
@@ -125,7 +125,9 @@ int main(int argc, char *argv[]) {
     }
 
     // Set the window class for Wayland
-    glfwWindowHintString(GLFW_WAYLAND_APP_ID, "GLWall");
+    const char* app_id = getenv("GLWALL_CLASS");
+    if (!app_id) app_id = "GLWall";
+    glfwWindowHintString(GLFW_WAYLAND_APP_ID, app_id);
 
     // Create a GLFW window
     GLFWwindow* window = glfwCreateWindow(WIDTH, HEIGHT, "GLWall", NULL, NULL);


### PR DESCRIPTION
This patch allows users to dynamically set the Wayland `app_id` (window class) using the `GLWALL_CLASS` environment variable.

This is useful for hyprwinwrap, and probably other things.
